### PR TITLE
Vertex normals, VTXNORMS chunk

### DIFF
--- a/addons/io_import_scene_unreal_psa_psk_280.py
+++ b/addons/io_import_scene_unreal_psa_psk_280.py
@@ -288,9 +288,6 @@ def util_check_file_header(file, ftype):
         
     if not header_bytes.startswith( PSKPSA_FILE_HEADER[ftype] ):
         return False
-
-    global header_type
-    header_type, = unpack('i', header_bytes[20:20+4])
         
     return True
         
@@ -546,7 +543,7 @@ def pskimport(filepath,
     #==================================================================================================
     # Vertex Normals NX | NY | NZ
     def read_normals():
-        if not bImportmesh or header_type != 30000101:
+        if not bImportmesh:
             return True
 
         nonlocal Normals
@@ -1047,7 +1044,7 @@ def pskimport(filepath,
     #==================================================================================================
     # Vertex Normal. Set.
 
-        if header_type == 30000101 and len(Normals) != 0:
+        if len(Normals) != 0:
             mesh_data.polygons.foreach_set("use_smooth", [True] * len(mesh_data.polygons))
             mesh_data.normals_split_custom_set_from_vertices(Normals)
             mesh_data.use_auto_smooth = True

--- a/addons/io_import_scene_unreal_psa_psk_280.py
+++ b/addons/io_import_scene_unreal_psa_psk_280.py
@@ -1047,7 +1047,7 @@ def pskimport(filepath,
     #==================================================================================================
     # Vertex Normal. Set.
 
-        if header_type == 30000101:
+        if header_type == 30000101 and len(Normals) != 0:
             mesh_data.polygons.foreach_set("use_smooth", [True] * len(mesh_data.polygons))
             mesh_data.normals_split_custom_set_from_vertices(Normals)
             mesh_data.use_auto_smooth = True

--- a/addons/io_import_scene_unreal_psa_psk_280.py
+++ b/addons/io_import_scene_unreal_psa_psk_280.py
@@ -1044,7 +1044,7 @@ def pskimport(filepath,
     #==================================================================================================
     # Vertex Normal. Set.
 
-        if len(Normals) != 0:
+        if Normals is not None:
             mesh_data.polygons.foreach_set("use_smooth", [True] * len(mesh_data.polygons))
             mesh_data.normals_split_custom_set_from_vertices(Normals)
             mesh_data.use_auto_smooth = True

--- a/addons/io_import_scene_unreal_psa_psk_280.py
+++ b/addons/io_import_scene_unreal_psa_psk_280.py
@@ -555,8 +555,7 @@ def pskimport(filepath,
         unpack_data = Struct('3f').unpack_from
 
         for counter in range(chunk_datacount):
-            (nx, ny, nz) = unpack_data(chunk_data, counter * chunk_datasize)
-            Normals[counter] = (nx, -ny, nz)
+            Normals[counter] = unpack_data(chunk_data, counter * chunk_datasize)
  
              
     CHUNKS_HANDLERS = {

--- a/addons/io_import_scene_unreal_psa_psk_280.py
+++ b/addons/io_import_scene_unreal_psa_psk_280.py
@@ -57,7 +57,7 @@ Github: https://github.com/Befzz/blender3d_import_psk_psa
 """
 
 """
-Version': '2.8.*' edited by floxay
+Version': '2.8.0' edited by floxay
 - Vertex normals import (VTXNORMS chunk)
         (requires custom UEViewer build /at the moment/)
 """


### PR DESCRIPTION
Since smoothing groups are not exported and the normal data is only exported with the glTF option most users never have the custom normals imported as they use ActorX.
Another issue is that psa animations don't really work with glTF armatures as-is.

I have a fork of UEViewer (https://github.com/floxay/UEViewer/commit/cc0542d373b209881ea44ae4cac7c932cf4389ca) that saves the normals into a VTXNORMS chunk and I'm opening this PR mainly because this 'unofficial' support for normals should not break importing old psk/pskx (probably should force it to pskx only) files but could be useful when encountering this 'new' chunk.

~~Edit: I only added it to the 280 script as I'm not sure if the 279 one would work the same way or not.~~
added to 270 too

Edit 2: [Vertex normals and ActorX [gildor.org]](https://www.gildor.org/smf/index.php/topic,7927.0.html)
If anyone reading this is familiar enough with MAXScript to implement this correctly into the 3ds Max importer (link above) that'd be appreciated, I tried but failed :D