### PR TITLE
Blender 3.1 Fix (Animations)

### DIFF
--- a/addons/io_import_scene_unreal_psa_psk_280.py
+++ b/addons/io_import_scene_unreal_psa_psk_280.py
@@ -1874,9 +1874,9 @@ def psaimport(filepath,
         if bActionsToTrack:
 
             if len(nla_track.strips) == 0:
-                strip = nla_stripes.new(action_name, nla_track_last_frame, action)
+                strip = nla_stripes.new(action_name, int(nla_track_last_frame), action)
             else:
-                strip = nla_stripes.new(action_name, nla_stripes[-1].frame_end, action)
+                strip = nla_stripes.new(action_name, int(nla_stripes[-1].frame_end), action)
 
             # Do not pollute track. Makes other tracks 'visible' through 'empty space'.
             strip.extrapolation = 'NOTHING'


### PR DESCRIPTION
New Blender versions fails to import the animation when a float is passed as start frame.

`
  File "C:\Users\ogulc\AppData\Roaming\Blender Foundation\Blender\3.1\scripts\addons\io_import_scene_unreal_psa_psk_280.py", line 1944, in psaimport
    strip = nla_stripes.new(action_name, nla_track_last_frame, action)
TypeError: NlaStrips.new(): error with argument 2, "start" -  Function.start expected an int type, not float
`